### PR TITLE
Convert docx to html with images and tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# Luojuanyun
+# DOCX 转 HTML（嵌入 Base64 图片）
+
+- 支持图片、表格
+- UTF-8 防乱码（需系统有中文字体）
+- 保留原样式（依赖 XWPF -> XHTML 转换）
+- 图片以 Base64 嵌入 HTML
+
+## 构建
+
+请使用本地已安装的 Gradle 或 IDE 构建。
+
+```
+# 无 wrapper 场景（示例）：
+# 在本仓库目录执行（需已安装 Gradle）
+# gradle clean shadowJar
+```
+
+若无 Gradle 环境，可在 IDE 里导入 Gradle 工程并执行 `shadowJar` 任务。
+
+构建产物：`build/libs/docx2html-1.0.0-all.jar`
+
+## 运行
+
+```
+java -jar build/libs/docx2html-1.0.0-all.jar input.docx output.html
+```
+
+- `input.docx`：源 Word 文档
+- `output.html`：输出 HTML 文件
+
+## 备注
+
+- 若出现中文字体显示异常，请确保运行环境安装了中文字体（如 `Noto Sans CJK`）。
+- 对非常复杂的 Word 样式，HTML 表达可能存在差异，建议结合目标场景测试与微调 CSS。

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'java'
+    id 'application'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+dependencies {
+    implementation 'org.apache.poi:poi-ooxml:5.2.5'
+    implementation 'fr.opensagres.xdocreport:org.apache.poi.xwpf.converter.core:2.0.3'
+    implementation 'fr.opensagres.xdocreport:org.apache.poi.xwpf.converter.xhtml:2.0.3'
+    implementation 'org.jsoup:jsoup:1.17.2'
+}
+
+application {
+    mainClass = 'com.example.docx2html.DocxToHtml'
+}
+
+// build fat jar
+shadowJar {
+    archiveBaseName.set('docx2html')
+    archiveVersion.set('1.0.0')
+    archiveClassifier.set('all')
+    mergeServiceFiles()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'docx2html'

--- a/src/main/java/com/example/docx2html/DocxToHtml.java
+++ b/src/main/java/com/example/docx2html/DocxToHtml.java
@@ -1,0 +1,121 @@
+package com.example.docx2html;
+
+import fr.opensagres.poi.xwpf.converter.xhtml.XHTMLConverter;
+import fr.opensagres.poi.xwpf.converter.xhtml.XHTMLOptions;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFPictureData;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class DocxToHtml {
+
+    private DocxToHtml() {}
+
+    public static void convert(Path inputDocxPath, Path outputHtmlPath) throws IOException {
+        Files.createDirectories(outputHtmlPath.toAbsolutePath().getParent());
+
+        try (InputStream inputStream = Files.newInputStream(inputDocxPath);
+             XWPFDocument document = new XWPFDocument(inputStream)) {
+
+            XHTMLOptions options = XHTMLOptions.create();
+            options.setIgnoreStylesIfUnused(false);
+            options.setFragment(false);
+
+            ByteArrayOutputStream htmlBuffer = new ByteArrayOutputStream(64 * 1024);
+            XHTMLConverter.getInstance().convert(document, htmlBuffer, options);
+
+            String html = htmlBuffer.toString(StandardCharsets.UTF_8);
+            if (!html.toLowerCase(Locale.ROOT).contains("<meta charset")) {
+                html = html.replaceFirst("(?i)<head>", "<head>\n<meta charset=\"UTF-8\"/>");
+            }
+
+            String htmlWithEmbeddedImages = embedImagesAsBase64(html, document);
+
+            try (BufferedWriter writer = Files.newBufferedWriter(outputHtmlPath, StandardCharsets.UTF_8)) {
+                writer.write(htmlWithEmbeddedImages);
+            }
+        }
+    }
+
+    private static String embedImagesAsBase64(String html, XWPFDocument document) {
+        Document doc = Jsoup.parse(html);
+        Elements imgElements = doc.select("img[src]");
+
+        List<XWPFPictureData> pictures = document.getAllPictures();
+        Map<String, XWPFPictureData> fileNameToPic = new HashMap<>();
+        for (XWPFPictureData picture : pictures) {
+            fileNameToPic.put(picture.getFileName(), picture);
+        }
+
+        for (Element img : imgElements) {
+            String src = img.attr("src");
+            String fileName = src;
+            int slash = src.lastIndexOf('/');
+            if (slash >= 0 && slash < src.length() - 1) {
+                fileName = src.substring(slash + 1);
+            }
+
+            XWPFPictureData pic = fileNameToPic.get(fileName);
+            if (pic != null) {
+                String ext = pic.suggestFileExtension();
+                String mime = toMimeType(ext);
+                String base64 = Base64.getEncoder().encodeToString(pic.getData());
+                img.attr("src", "data:" + mime + ";base64," + base64);
+            }
+        }
+
+        return doc.outerHtml();
+    }
+
+    private static String toMimeType(String ext) {
+        if (ext == null) {
+            return "application/octet-stream";
+        }
+        String e = ext.toLowerCase(Locale.ROOT);
+        switch (e) {
+            case "png":
+                return "image/png";
+            case "jpg":
+            case "jpeg":
+                return "image/jpeg";
+            case "gif":
+                return "image/gif";
+            case "bmp":
+                return "image/bmp";
+            case "svg":
+                return "image/svg+xml";
+            case "tif":
+            case "tiff":
+                return "image/tiff";
+            default:
+                return "application/octet-stream";
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("用法: java -jar app.jar <input.docx> <output.html>");
+            System.exit(1);
+        }
+        Path input = Paths.get(args[0]);
+        Path output = Paths.get(args[1]);
+        convert(input, output);
+        System.out.println("转换完成: " + output.toAbsolutePath());
+    }
+}


### PR DESCRIPTION
Implement DOCX to HTML conversion with embedded Base64 images, preserved styles, and UTF-8 support within a Gradle project.

---
<a href="https://cursor.com/background-agent?bcId=bc-37123ab0-c510-4bdf-9eb3-06d032c09b38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37123ab0-c510-4bdf-9eb3-06d032c09b38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

